### PR TITLE
this adds policy download ability

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,11 @@
 repos:
--   repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v1.2.3
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.4.3
     hooks:
-            -   id: autopep8-wrapper
+            -   id: autopep8
+-   repo: git://github.com/pre-commit/pre-commit-hooks
+    rev: v2.0.0
+    hooks:
             -   id: fix-encoding-pragma
             -   id: trailing-whitespace
             -   id: flake8
@@ -47,7 +50,7 @@ repos:
                 language: system
                 types: [python]
 -   repo: git://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.5
+    rev: v1.1.6
     hooks:
     -   id: remove-tabs
     -   id: remove-crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,60 @@
 language: python
+addons:
+  apt:
+    sources:
+    - elasticsearch-5.x
+    packages:
+    - elasticsearch
+    - oracle-java8-set-default
 services:
+- elasticsearch
+- postgresql
 - rabbitmq
+env:
+  PEEWEE_URL: postgres://postgres:@localhost/pacifica_metadata
 stages:
 - lint
 - test
 - deploy
 ".before_script": &2
-- export CARTD_CPCONFIG="$PWD/travis/cartd/server.conf"
+- psql -c 'create database pacifica_metadata;' -U postgres
 - export ARCHIVEINTERFACE_CPCONFIG="$PWD/travis/archive/server.conf"
 - export ARCHIVEINTERFACE_CONFIG="$PWD/travis/archive/config.cfg"
 - pacifica-archiveinterface & echo $! > archive.pid
+- export METADATA_CPCONFIG="$PWD/travis/metadata/server.conf"
+- pacifica-metadata-cmd dbsync
+- pacifica-metadata & echo $! > metadata.pid
+- export CARTD_CPCONFIG="$PWD/travis/cartd/server.conf"
 - pacifica-cartd-cmd dbsync
 - pacifica-cartd & echo $! > cartd.pid
 - celery -A pacifica.cartd.tasks worker -l info -P solo -c 1 & echo $! > celery.pid
-- sleep 4
+- |
+  MAX_TRIES=60
+  HTTP_CODE=$(curl -sL -w "%{http_code}\\n" localhost:8121/keys -o /dev/null || true)
+  while [[ $HTTP_CODE != 200 && $MAX_TRIES > 0 ]] ; do
+    sleep 1
+    HTTP_CODE=$(curl -sL -w "%{http_code}\\n" localhost:8121/keys -o /dev/null || true)
+    MAX_TRIES=$(( MAX_TRIES - 1 ))
+  done
+- |
+  TOP_DIR=$PWD
+  MD_TEMP=$(mktemp -d)
+  VERSION=$(pip show pacifica-metadata | grep Version: | awk '{ print $2 }')
+  git clone https://github.com/pacifica/pacifica-metadata.git ${MD_TEMP}
+  pushd ${MD_TEMP}
+  git checkout v${VERSION}
+  python tests/test_files/loadit_test.py
+  popd
+- |
+  curl -X PUT -H 'Last-Modified: Sun, 06 Nov 1994 08:49:37 GMT' --upload-file README.md http://127.0.0.1:8080/103
+  curl -X PUT -H 'Last-Modified: Sun, 06 Nov 1994 08:49:37 GMT' --upload-file README.md http://127.0.0.1:8080/104
+  readme_size=$(stat -c '%s' README.md)
+  readme_sha1=$(sha1sum README.md | awk '{ print $1 }')
+  echo '{ "hashsum": "'$readme_sha1'", "hashtype": "sha1", "size": '$readme_size'}' > /tmp/file-104-update.json
+  curl -X POST -H 'content-type: application/json' -T /tmp/file-104-update.json 'http://localhost:8121/files?_id=103'
+  curl -X POST -H 'content-type: application/json' -T /tmp/file-104-update.json 'http://localhost:8121/files?_id=104'
+- export POLICY_CPCONFIG="$PWD/travis/policy/server.conf"
+- pacifica-policy & echo $! > policy.pid
 - python test_files/archiveinterfacepreload.py
 ".script": &1
 - pip install .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,14 @@ version: 0.1.{build}
 pull_requests:
   do_not_increment_build_number: true
 
+services:
+- postgresql
+
 environment:
+  PGUSER: postgres
+  PGPASSWORD: Password12!
+  PGSQL_PATH: C:\Program Files\PostgreSQL\9.6
+  PEEWEE_URL: postgres://postgres:Password12!@localhost/pacifica_metadata
   BROKER_URL: redis://127.0.0.1:6379/0
   BACKEND_URL: redis://127.0.0.1:6379/0
   matrix:
@@ -13,6 +20,9 @@ install:
   - ps: >
       & "$env:PYTHON\python.exe" -m virtualenv C:\pacifica;
       C:\pacifica\Scripts\activate.ps1;
+      Invoke-WebRequest -Uri "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.5.zip" -OutFile "elasticsearch.zip";
+      Expand-Archive "elasticsearch.zip" -DestinationPath "C:\elasticsearch";
+      Start-Process C:\elasticsearch\elasticsearch-5.6.5\bin\elasticsearch;
       python -m pip install --upgrade pip setuptools wheel;
       nuget install redis-64 -excludeversion;
       redis-64\tools\redis-server.exe --service-install;
@@ -22,25 +32,48 @@ install:
 
 build: off
 
+before_test:
+- ps: >
+    $env:PATH = "${env:PGSQL_PATH}\bin;${env:PYTHON}\Scripts;${env:PATH}";
+    createdb pacifica_metadata;
+    C:\pacifica\Scripts\activate.ps1;
+    $env:METADATA_CPCONFIG = "$PWD/travis/metadata/server.conf";
+    $env:POLICY_CPCONFIG = "$PWD/travis/policy/server.conf";
+    $env:CARTD_CPCONFIG = "$PWD/travis/cartd/server.conf";
+    $env:ARCHIVEINTERFACE_CPCONFIG = "$PWD/travis/archive/server.conf";
+    $env:ARCHIVEINTERFACE_CONFIG = "$PWD/travis/archive/config.cfg";
+    C:\pacifica\Scripts\pacifica-metadata-cmd.exe dbsync;
+    Start-Process C:\pacifica\Scripts\pacifica-metadata.exe -RedirectStandardError metadata-error.log -RedirectStandardOutput metadata-output.log;
+    C:\pacifica\Scripts\pacifica-cartd-cmd.exe dbsync;
+    Start-Process C:\pacifica\Scripts\pacifica-cartd.exe -RedirectStandardError server-error.log -RedirectStandardOutput server-output.log;
+    Start-Process C:\pacifica\Scripts\celery.exe -ArgumentList "-A pacifica.cartd.tasks worker -l info -P solo -c 1" -RedirectStandardError celery-error.log -RedirectStandardOutput celery-output.log;
+    Start-Process C:\pacifica\Scripts\pacifica-archiveinterface.exe -RedirectStandardError archive-error.log -RedirectStandardOutput archive-output.log;
+    $MD_VERSION = `pip show pacifica-metadata | grep Version: | awk '{ print $2 }';
+    Invoke-WebRequest https://github.com/pacifica/pacifica-metadata/archive/v${MD_VERSION}.zip -OutFile pacifica-metadata.zip;
+    Expand-Archive pacifica-metadata.zip -DestinationPath C:\pacifica-metadata;
+    pushd C:\pacifica-metadata\pacifica-metadata-${MD_VERSION};
+    sleep 10; Invoke-WebRequest http://localhost:8121/users;
+    python tests\test_files\loadit_test.py;
+    popd;
+    python test_files\archiveinterfacepreload.py;
+    Invoke-WebRequest -InFile README.md -Method PUT -Headers @{'Last-Modified'='Sun, 06 Nov 1994 08:49:37 GMT'} http://127.0.0.1:8080/103;
+    Invoke-WebRequest -InFile README.md -Method PUT -Headers @{'Last-Modified'='Sun, 06 Nov 1994 08:49:37 GMT'} http://127.0.0.1:8080/104;
+    $size = (Get-Item README.md).length;
+    $hash = (Get-FileHash -Algorithm sha1 readme.md).hash;
+    '{ "hashsum": "'+$hash.ToLower()+'", "hashtype": "sha1", "size": '+$size+'}' | Invoke-WebRequest -Method POST -Headers @{ "content-type" = "application/json" } http://127.0.0.1:8121/files?_id=103;
+    '{ "hashsum": "'+$hash.ToLower()+'", "hashtype": "sha1", "size": '+$size+'}' | Invoke-WebRequest -Method POST -Headers @{ "content-type" = "application/json" } http://127.0.0.1:8121/files?_id=104;
+    $env:METADATA_URL = "http://127.0.0.1:8121";
+    $env:STATUS_URL = "http://127.0.0.1:8121/groups";
+    Start-Process C:\pacifica\Scripts\pacifica-policy.exe -RedirectStandardError policy-error.log -RedirectStandardOutput policy-output.log;
+    sleep 5;
+    Invoke-WebRequest http://127.0.0.1:8181/status/transactions/by_id/67;
+
 test_script:
   - ps: >
-      $env:CARTD_CPCONFIG = "$PWD/travis/cartd/server.conf";
-      $env:ARCHIVEINTERFACE_CPCONFIG = "$PWD/travis/archive/server.conf";
-      $env:ARCHIVEINTERFACE_CONFIG = "$PWD/travis/archive/config.cfg";
+      $env:ARCHIVE_INTERFACE_URL = 'http://127.0.0.1:8080/';
       mkdir C:\tmp; C:\pacifica\Scripts\activate.ps1;
       pre-commit run -a;
-      $ai_proc = Start-Process C:\pacifica\Scripts\pacifica-archiveinterface.exe -PassThru -RedirectStandardError archive-error.log -RedirectStandardOutput archive-output.log;
-      $env:ARCHIVE_INTERFACE_URL = 'http://127.0.0.1:8080/';
-      C:\pacifica\Scripts\pacifica-cartd-cmd.exe dbsync;
-      $back_proc = Start-Process C:\pacifica\Scripts\celery.exe -ArgumentList "-A pacifica.cartd.tasks worker -l info -P solo -c 1" -PassThru -RedirectStandardError celery-error.log -RedirectStandardOutput celery-output.log;
-      $front_proc = Start-Process C:\pacifica\Scripts\pacifica-cartd.exe -PassThru -RedirectStandardError server-error.log -RedirectStandardOutput server-output.log;
-      sleep 4;
-      python test_files\archiveinterfacepreload.py;
       pip install .;
       cd tests;
       coverage run --include='*/site-packages/pacifica/downloader/*' -m pytest -v;
-      celery -A pacifica.cartd.tasks control shutdown;
-      $back_proc | Stop-Process;
-      $front_proc | Stop-Process;
-      $ai_proc | Stop-Process;
       coverage report -m --fail-under=100;

--- a/pacifica/downloader/cartapi.py
+++ b/pacifica/downloader/cartapi.py
@@ -29,9 +29,9 @@ class CartAPI(object):
         assert resp.status_code == 201
         return cart_url
 
-    def wait_for_cart(self, cart_url):
+    def wait_for_cart(self, cart_url, timeout=120):
         """Wait for cart completion to finish."""
-        while True:
+        while timeout > 0:
             resp = self.session.head(cart_url)
             resp_status = resp.headers['X-Pacifica-Status']
             resp_message = resp.headers['X-Pacifica-Message']
@@ -41,7 +41,8 @@ class CartAPI(object):
             if resp_code == 500:  # pragma: no cover
                 logging.error(resp_message)
                 break
-            time.sleep(2)
+            time.sleep(1)
+            timeout -= 1
         assert resp_status == 'ready'
         assert resp_code == 204
         return cart_url

--- a/pacifica/downloader/policy.py
+++ b/pacifica/downloader/policy.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Policy Parser."""
+
+
+# pylint: disable=too-few-public-methods
+class TransactionInfo(object):
+    """Cloud Event Parser."""
+
+    @staticmethod
+    def yield_files(transinfo):
+        """returned lambda method for yield files."""
+        def ce_yield_files():
+            """yield files from a cloudevent object."""
+            for file_id, file_obj in transinfo.get('files', {}).items():
+                yield {
+                    'id': file_id,
+                    'path': '{}/{}'.format(
+                        file_obj.get('subdir', ''),
+                        file_obj.get('name', False)
+                    ),
+                    'hashsum': file_obj.get('hashsum', False),
+                    'hashtype': file_obj.get('hashtype', False)
+                }
+        return ce_yield_files
+# pylint: enable=too-few-public-methods

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,8 @@ codeclimate-test-reporter
 coverage>4.0,<4.4
 pacifica-archiveinterface
 pacifica-cartd
+pacifica-metadata
+pacifica-policy
 pep257
 pre-commit
 pre-commit

--- a/test_files/archiveinterfacepreload.py
+++ b/test_files/archiveinterfacepreload.py
@@ -4,7 +4,7 @@
 import requests
 
 SESSION = requests.Session()
-for i in range(100, 110):
+for i in range(1100, 1110):
     resp = SESSION.put(
         'http://127.0.0.1:8080/{}'.format(i),
         data='The data for file {}.\n'.format(i)

--- a/tests/downloader_test.py
+++ b/tests/downloader_test.py
@@ -6,11 +6,23 @@ from os.path import exists, join
 from tempfile import mkdtemp
 from hashlib import sha1
 from unittest import TestCase
+import requests
 from pacifica.downloader import Downloader
 
 
 class TestDownloader(TestCase):
     """Test the Downloader class."""
+
+    def test_download_policy(self):
+        """Test the download with policy."""
+        down_path = mkdtemp()
+        down = Downloader(down_path, 'http://127.0.0.1:8081')
+        resp = requests.get('http://127.0.0.1:8181/status/transactions/by_id/67')
+        self.assertEqual(resp.status_code, 200)
+        down.transactioninfo(resp.json())
+        self.assertTrue(exists(join(down_path, 'data', 'a', 'b', 'foo.txt')))
+        self.assertTrue(exists(join(down_path, 'data', 'a', 'b', 'bar.txt')))
+        rmtree(down_path)
 
     def test_download_cloudevent(self):
         """Test the download method in example class."""
@@ -28,13 +40,13 @@ class TestDownloader(TestCase):
                     'subdir': 'subdir_{}'.format(file_id),
                     'hashsum': sha1sum('The data for file {}.\n'.format(file_id).encode('utf8')),
                     'hashtype': 'sha1'
-                } for file_id in range(100, 110)
+                } for file_id in range(1100, 1110)
             ]
         }
         down_path = mkdtemp()
         down = Downloader(down_path, 'http://127.0.0.1:8081')
         down.cloudevent(cloud_event_stub)
-        for file_id in range(100, 110):
+        for file_id in range(1100, 1110):
             self.assertTrue(
                 exists(join(down_path, 'data', 'subdir_{}'.format(file_id), 'file.{}.txt'.format(file_id))))
         rmtree(down_path)

--- a/travis/metadata/server.conf
+++ b/travis/metadata/server.conf
@@ -1,0 +1,11 @@
+[global]
+log.screen: True
+log.access_file: 'access.log'
+log.error_file: 'error.log'
+server.socket_host: '0.0.0.0'
+server.socket_port: 8121
+
+[/]
+request.dispatch: cherrypy.dispatch.MethodDispatcher()
+tools.response_headers.on: True
+tools.response_headers.headers: [('Content-Type', 'application/json')]

--- a/travis/policy/server.conf
+++ b/travis/policy/server.conf
@@ -1,0 +1,11 @@
+[global]
+log.screen: True
+log.access_file: 'access.log'
+log.error_file: 'error.log'
+server.socket_host: '0.0.0.0'
+server.socket_port: 8181
+
+[/]
+request.dispatch: cherrypy.dispatch.MethodDispatcher()
+tools.response_headers.on: True
+tools.response_headers.headers: [('Content-Type', 'application/json')]


### PR DESCRIPTION
### Description

This adds the ability to ask the policy server for information about a transaction
and allows users to download that transaction.

This does a lot as it need to invoke the metadata/policy stack in the testing
pipelines.

Signed-off-by: David Brown <dmlb2000@gmail.com>


### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
