### PR TITLE
add optional auth hash for requests sessions

### DIFF
--- a/pacifica/downloader/cartapi.py
+++ b/pacifica/downloader/cartapi.py
@@ -15,6 +15,7 @@ class CartAPI(object):
         """Constructor for cart api."""
         self.cart_api_url = cart_api_url
         self.session = kwargs.get('session', requests.Session())
+        self.auth = kwargs.get('auth', {})
 
     def setup_cart(self, yield_files):
         """Setup a cart from the cloudevent object return url to the download."""
@@ -24,7 +25,8 @@ class CartAPI(object):
             data=dumps({
                 'fileids': [file_obj for file_obj in yield_files()]
             }),
-            headers={'Content-Type': 'application/json'}
+            headers={'Content-Type': 'application/json'},
+            **self.auth
         )
         assert resp.status_code == 201
         return cart_url
@@ -32,7 +34,7 @@ class CartAPI(object):
     def wait_for_cart(self, cart_url, timeout=120):
         """Wait for cart completion to finish."""
         while timeout > 0:
-            resp = self.session.head(cart_url)
+            resp = self.session.head(cart_url, **self.auth)
             resp_status = resp.headers['X-Pacifica-Status']
             resp_message = resp.headers['X-Pacifica-Message']
             resp_code = resp.status_code

--- a/pacifica/downloader/downloader.py
+++ b/pacifica/downloader/downloader.py
@@ -11,14 +11,18 @@ from .policy import TransactionInfo
 class Downloader(object):
     """Downloader Class."""
 
-    def __init__(self, location, cart_api_url):
+    def __init__(self, location, cart_api_url, **kwargs):
         """Create the downloader given directory location."""
         self.location = location
-        self.cart_api = CartAPI(cart_api_url)
+        self.auth = kwargs.get('auth', {})
+        self.cart_api = CartAPI(cart_api_url, auth=self.auth)
 
     def _download_from_url(self, cart_url, filename):
         """Download the cart from the url."""
-        resp = requests.get('{}?filename={}'.format(cart_url, filename), stream=True)
+        resp = requests.get(
+            '{}?filename={}'.format(cart_url, filename),
+            stream=True, **self.auth
+        )
         cart_tar = tarfile.open(name=None, mode='r|', fileobj=resp.raw)
         cart_tar.extractall(self.location)
         cart_tar.close()


### PR DESCRIPTION
### Description

This adds a way to pass authentication information into requests
methods for accessing core services.

Signed-off-by: David Brown <dmlb2000@gmail.com>


### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
