### PR TITLE
Add retry handler to default session.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ install:
       redis-64\tools\redis-server.exe --service-start;
       python -m pip install -r requirements-dev.txt;
       python -m pip install 'redis<3.0';
+      echo 'Done';
 
 build: off
 

--- a/pacifica/downloader/cartapi.py
+++ b/pacifica/downloader/cartapi.py
@@ -27,7 +27,11 @@ class CartAPI(object):
         dictionary can be passed via keyword arguments.
         """
         self.cart_api_url = cart_api_url
-        self.session = kwargs.get('session', requests.Session())
+        adapter = requests.adapters.HTTPAdapter(max_retries=5)
+        session = requests.Session()
+        session.mount('http://', adapter)
+        session.mount('https://', adapter)
+        self.session = kwargs.get('session', session)
         self.auth = kwargs.get('auth', {})
 
     def setup_cart(self, yield_files):


### PR DESCRIPTION
### Description

This adds a simple retry handler to the default session in the
CartAPI constructor.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

Fix #12 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
