### PR TITLE
Remove location argument from constructor for Downloader class

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
       redis-64\tools\redis-server.exe --service-install;
       redis-64\tools\redis-server.exe --service-start;
       python -m pip install -r requirements-dev.txt;
-      python -m pip install 'redis<3.0';
+      python -m pip install 'redis';
       echo 'Done';
 
 build: off
@@ -76,5 +76,5 @@ test_script:
       pre-commit run -a;
       pip install .;
       cd tests;
-      coverage run --include='*/site-packages/pacifica/downloader/*' -m pytest -v;
+      coverage run --include='*/site-packages/pacifica/downloader/*' -m pytest -xv;
       coverage report -m --fail-under=100;

--- a/docs/exampleusage.md
+++ b/docs/exampleusage.md
@@ -14,10 +14,10 @@ download the data to.
 from tempfile import mkdtemp
 
 down_path = mkdtemp()
-down = Downloader(down_path, 'http://127.0.0.1:8081')
+down = Downloader('http://127.0.0.1:8081')
 resp = requests.get('http://127.0.0.1:8181/status/transactions/by_id/67')
 assert resp.status_code == 200
-down.transactioninfo(resp.json())
+down.transactioninfo(down_path, resp.json())
 ```
 
 ## Download Cloud Event
@@ -39,8 +39,8 @@ class Root(object):
     def POST(self):
         """Accept the cloud event data and return the local download path."""
         down_path = mkdtemp()
-        down = Downloader(down_path, 'http://127.0.0.1:8081')
-        down.cloudevent(cherrpy.request.json)
+        down = Downloader('http://127.0.0.1:8081')
+        down.cloudevent(down_path, cherrpy.request.json)
         return { 'download_path': down_path }
 
 

--- a/pacifica/downloader/downloader.py
+++ b/pacifica/downloader/downloader.py
@@ -12,24 +12,21 @@ class Downloader(object):
     """
     Downloader Class.
 
-    The constructor takes two arguments `location` and
-    `cart_api_url`. The `location` is a download directory to be
-    created by a download method. The `cart_api_url` is the endpoint
-    for creating carts.
+    The constructor takes one argument: `cart_api_url`.
+    The `cart_api_url` is the endpoint for creating carts.
 
     The other methods in this class are the supported
     download methods. Each method takes appropriate input for that
     method and the method will download the data to the location
-    defined in the constructor.
+    specified in the method's arguments.
     """
 
-    def __init__(self, location, cart_api_url, **kwargs):
+    def __init__(self, cart_api_url, **kwargs):
         """Create the downloader given directory location."""
-        self.location = location
         self.auth = kwargs.get('auth', {})
         self.cart_api = CartAPI(cart_api_url, auth=self.auth)
 
-    def _download_from_url(self, cart_url, filename):
+    def _download_from_url(self, location, cart_url, filename):
         """
         Download the cart from the url.
 
@@ -40,10 +37,10 @@ class Downloader(object):
             stream=True, **self.auth
         )
         cart_tar = tarfile.open(name=None, mode='r|', fileobj=resp.raw)
-        cart_tar.extractall(self.location)
+        cart_tar.extractall(location)
         cart_tar.close()
 
-    def transactioninfo(self, transinfo, filename='data'):
+    def transactioninfo(self, location, transinfo, filename='data'):
         """
         Handle transaction info and download the data in a cart.
 
@@ -51,6 +48,7 @@ class Downloader(object):
         `PolicyAPI <https://pacifica-policy.readthedocs.io/>`_.
         """
         self._download_from_url(
+            location,
             self.cart_api.wait_for_cart(
                 self.cart_api.setup_cart(
                     TransactionInfo.yield_files(transinfo)
@@ -59,7 +57,7 @@ class Downloader(object):
             filename
         )
 
-    def cloudevent(self, cloudevent, filename='data'):
+    def cloudevent(self, location, cloudevent, filename='data'):
         """
         Handle a cloud event and download the data in a cart.
 
@@ -71,6 +69,7 @@ class Downloader(object):
         service.
         """
         self._download_from_url(
+            location,
             self.cart_api.wait_for_cart(
                 self.cart_api.setup_cart(
                     CloudEvent.yield_files(cloudevent)

--- a/pacifica/downloader/policy.py
+++ b/pacifica/downloader/policy.py
@@ -20,7 +20,7 @@ class TransactionInfo(object):
             for file_id, file_obj in transinfo.get('files', {}).items():
                 yield {
                     'id': file_id,
-                    'path': '{}/{}'.format(
+                    'path': u'{}/{}'.format(
                         file_obj.get('subdir', ''),
                         file_obj.get('name', False)
                     ),

--- a/tests/downloader_test.py
+++ b/tests/downloader_test.py
@@ -21,7 +21,7 @@ class TestDownloader(TestCase):
         self.assertEqual(resp.status_code, 200)
         down.transactioninfo(down_path, resp.json())
         self.assertTrue(exists(join(down_path, 'data', 'a', 'b', 'foo.txt')))
-        self.assertTrue(exists(join(down_path, 'data', 'a', 'b', 'bar.txt')))
+        self.assertTrue(exists(join(down_path, 'data', 'a', 'b', u'\u00e9', u'bar\u00e9.txt')))
         rmtree(down_path)
 
     def test_download_cloudevent(self):

--- a/tests/downloader_test.py
+++ b/tests/downloader_test.py
@@ -16,10 +16,10 @@ class TestDownloader(TestCase):
     def test_download_policy(self):
         """Test the download with policy."""
         down_path = mkdtemp()
-        down = Downloader(down_path, 'http://127.0.0.1:8081')
+        down = Downloader('http://127.0.0.1:8081')
         resp = requests.get('http://127.0.0.1:8181/status/transactions/by_id/67')
         self.assertEqual(resp.status_code, 200)
-        down.transactioninfo(resp.json())
+        down.transactioninfo(down_path, resp.json())
         self.assertTrue(exists(join(down_path, 'data', 'a', 'b', 'foo.txt')))
         self.assertTrue(exists(join(down_path, 'data', 'a', 'b', 'bar.txt')))
         rmtree(down_path)
@@ -44,8 +44,8 @@ class TestDownloader(TestCase):
             ]
         }
         down_path = mkdtemp()
-        down = Downloader(down_path, 'http://127.0.0.1:8081')
-        down.cloudevent(cloud_event_stub)
+        down = Downloader('http://127.0.0.1:8081')
+        down.cloudevent(down_path, cloud_event_stub)
         for file_id in range(1100, 1110):
             self.assertTrue(
                 exists(join(down_path, 'data', 'subdir_{}'.format(file_id), 'file.{}.txt'.format(file_id))))


### PR DESCRIPTION
Having the `location` argument be part of the constructor for the `Downloader` class means that instances may only be used once, since it forces all downloaded files to be in the same location on disk.

If the `location` argument is removed and then supplied as an argument to each instance method, then the same instance may be used multiple times, with each set of downloaded files going to [potentially -- as determined by the caller] a different location on disk.

### Description

* Removed `location` argument from constructor for `Downloader` class.
* Added `location` argument to instance methods of `Downloader` class.

### Issues Resolved

None

### Check List

- [x] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
