### PR TITLE
Construct CartAPI URL from OS environment variables

### DIFF
--- a/docs/exampleusage.md
+++ b/docs/exampleusage.md
@@ -14,7 +14,7 @@ download the data to.
 from tempfile import mkdtemp
 
 down_path = mkdtemp()
-down = Downloader(down_path, 'http://127.0.0.1:8081')
+down = Downloader(down_path, cart_api_url='http://127.0.0.1:8081')
 resp = requests.get('http://127.0.0.1:8181/status/transactions/by_id/67')
 assert resp.status_code == 200
 down.transactioninfo(resp.json())
@@ -39,7 +39,7 @@ class Root(object):
     def POST(self):
         """Accept the cloud event data and return the local download path."""
         down_path = mkdtemp()
-        down = Downloader(down_path, 'http://127.0.0.1:8081')
+        down = Downloader(down_path, cart_api_url='http://127.0.0.1:8081')
         down.cloudevent(cherrpy.request.json)
         return { 'download_path': down_path }
 

--- a/pacifica/downloader/__init__.py
+++ b/pacifica/downloader/__init__.py
@@ -8,6 +8,6 @@ internal classes to pull the metadata required to interact with the
 Cartd service.
 """
 from __future__ import absolute_import
-from .downloader import Downloader # noqa: F401
+from .downloader import Downloader  # noqa: F401
 
 __all__ = ('Downloader')

--- a/pacifica/downloader/__init__.py
+++ b/pacifica/downloader/__init__.py
@@ -8,6 +8,6 @@ internal classes to pull the metadata required to interact with the
 Cartd service.
 """
 from __future__ import absolute_import
-from .downloader import Downloader
+from .downloader import Downloader # noqa: F401
 
 __all__ = ('Downloader')

--- a/pacifica/downloader/__init__.py
+++ b/pacifica/downloader/__init__.py
@@ -10,4 +10,4 @@ Cartd service.
 from __future__ import absolute_import
 from .downloader import Downloader
 
-__all__ = ['Downloader']
+__all__ = ('Downloader')

--- a/pacifica/downloader/cartapi.py
+++ b/pacifica/downloader/cartapi.py
@@ -77,6 +77,7 @@ class CartAPI(CommonBase):
             headers={'Content-Type': 'application/json'},
             **self._auth
         )
+        LOGGER.debug('CartAPI Setup Resp %s code %s', resp.json(), resp.status_code)
         assert resp.status_code == 201
         return cart_url
 
@@ -93,6 +94,7 @@ class CartAPI(CommonBase):
             resp_status = resp.headers['X-Pacifica-Status']
             resp_message = resp.headers['X-Pacifica-Message']
             resp_code = resp.status_code
+            LOGGER.debug('CartAPI Wait Resp %s code %s status %s message %s', resp.json(), resp_code, resp_status, resp_message.replace('"', '\\"'))
             if resp_code == 204 and resp_status != 'staging':
                 break
             if resp_code == 500:  # pragma: no cover

--- a/pacifica/downloader/cartapi.py
+++ b/pacifica/downloader/cartapi.py
@@ -60,9 +60,7 @@ class CartAPI(CommonBase):
 
     @property
     def auth(self):
-        """
-        Returns the requests authentication dictionary.
-        """
+        """Return the requests authentication dictionary."""
         return self._auth
 
     def setup_cart(self, yield_files):

--- a/pacifica/downloader/cartapi.py
+++ b/pacifica/downloader/cartapi.py
@@ -98,7 +98,8 @@ class CartAPI(CommonBase):
             resp_status = resp.headers['X-Pacifica-Status']
             resp_message = resp.headers['X-Pacifica-Message']
             resp_code = resp.status_code
-            LOGGER.debug('CartAPI Wait Resp %s code %s status %s message %s', resp.json(), resp_code, resp_status, resp_message.replace('"', '\\"'))
+            LOGGER.debug('CartAPI Wait Resp %s code %s status %s message %s', resp.json(),
+                         resp_code, resp_status, resp_message.replace('"', '\\"'))
             if resp_code == 204 and resp_status != 'staging':
                 break
             if resp_code == 500:  # pragma: no cover

--- a/pacifica/downloader/cartapi.py
+++ b/pacifica/downloader/cartapi.py
@@ -48,7 +48,7 @@ class CartAPI(CommonBase):
                 ('addr', '127.0.0.1'),
                 ('cart_api_url', None),
             ],
-            'CART',
+            'CARTD',
             kwargs
         )
 

--- a/pacifica/downloader/cartapi.py
+++ b/pacifica/downloader/cartapi.py
@@ -81,7 +81,7 @@ class CartAPI(CommonBase):
             headers={'Content-Type': 'application/json'},
             **self._auth
         )
-        LOGGER.debug('CartAPI Setup Resp %s code %s', resp.json(), resp.status_code)
+        LOGGER.debug('CartAPI Setup code %s', resp.status_code)
         assert resp.status_code == 201
         return cart_url
 
@@ -98,7 +98,7 @@ class CartAPI(CommonBase):
             resp_status = resp.headers['X-Pacifica-Status']
             resp_message = resp.headers['X-Pacifica-Message']
             resp_code = resp.status_code
-            LOGGER.debug('CartAPI Wait Resp %s code %s status %s message %s', resp.json(),
+            LOGGER.debug('CartAPI Wait code %s status %s message %s',
                          resp_code, resp_status, resp_message.replace('"', '\\"'))
             if resp_code == 204 and resp_status != 'staging':
                 break

--- a/pacifica/downloader/cartapi.py
+++ b/pacifica/downloader/cartapi.py
@@ -63,6 +63,11 @@ class CartAPI(CommonBase):
         """Return the requests authentication dictionary."""
         return self._auth
 
+    @property
+    def cart_api_url(self):
+        """Return the CartAPI URL."""
+        return self._cart_api_url
+
     def setup_cart(self, yield_files):
         """
         Setup a cart from the method and return url to the download.

--- a/pacifica/downloader/cartapi.py
+++ b/pacifica/downloader/cartapi.py
@@ -5,7 +5,6 @@ import logging
 from uuid import uuid4 as uuid
 import time
 from json import dumps
-import requests
 from .common import CommonBase
 
 

--- a/pacifica/downloader/cartapi.py
+++ b/pacifica/downloader/cartapi.py
@@ -58,6 +58,13 @@ class CartAPI(CommonBase):
 
         LOGGER.debug('CartAPI URL %s auth %s', self._cart_api_url, self._auth)
 
+    @property
+    def auth(self):
+        """
+        Returns the requests authentication dictionary.
+        """
+        return self._auth
+
     def setup_cart(self, yield_files):
         """
         Setup a cart from the method and return url to the download.

--- a/pacifica/downloader/common/__init__.py
+++ b/pacifica/downloader/common/__init__.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+"""Common downloader functionality."""
+from os import getenv
+import requests
+
+
+# pylint: disable=too-few-public-methods
+class CommonBase(object):
+    """Contains methods to implement common functionality."""
+
+    session = None
+
+    def _setup_requests_session(self):
+        """Setup a requests retry session so we can talk to http services."""
+        self.session = requests.session()
+        retry_adapter = requests.adapters.HTTPAdapter(max_retries=5)
+        self.session.mount('https://', retry_adapter)
+        self.session.mount('http://', retry_adapter)
+
+    def _server_url(self, parts, env_prefix, kwargs):
+        """Server URL parsing for init class method."""
+        for part, default in parts:
+            attr_name = '_{}'.format(part)
+            setattr(self, attr_name, kwargs.get(part))
+            if not getattr(self, attr_name):
+                setattr(self, attr_name, getenv('{}{}'.format(
+                    env_prefix, attr_name.upper()), default))
+# pylint: enable=too-few-public-methods

--- a/pacifica/downloader/downloader.py
+++ b/pacifica/downloader/downloader.py
@@ -12,10 +12,9 @@ class Downloader(object):
     """
     Downloader Class.
 
-    The constructor takes two arguments `location` and
-    `cart_api_url`. The `location` is a download directory to be
-    created by a download method. The `cart_api_url` is the endpoint
-    for creating carts.
+    The constructor takes one argument `location`.
+    The `location` is a download directory to be created by a download method.
+    Keyword arguments are delegated to the CartAPI constructor.
 
     The other methods in this class are the supported
     download methods. Each method takes appropriate input for that
@@ -23,11 +22,10 @@ class Downloader(object):
     defined in the constructor.
     """
 
-    def __init__(self, location, cart_api_url, **kwargs):
+    def __init__(self, location, **kwargs):
         """Create the downloader given directory location."""
         self.location = location
-        self.auth = kwargs.get('auth', {})
-        self.cart_api = CartAPI(cart_api_url, auth=self.auth)
+        self.cart_api = CartAPI(**kwargs)
 
     def _download_from_url(self, cart_url, filename):
         """
@@ -37,7 +35,7 @@ class Downloader(object):
         """
         resp = requests.get(
             '{}?filename={}'.format(cart_url, filename),
-            stream=True, **self.auth
+            stream=True, **self.cart_api._auth
         )
         cart_tar = tarfile.open(name=None, mode='r|', fileobj=resp.raw)
         cart_tar.extractall(self.location)

--- a/pacifica/downloader/downloader.py
+++ b/pacifica/downloader/downloader.py
@@ -34,7 +34,7 @@ class Downloader(object):
         """
         resp = requests.get(
             '{}?filename={}'.format(cart_url, filename),
-            stream=True, **self.cart_api._auth
+            stream=True, **self.cart_api.auth
         )
         cart_tar = tarfile.open(name=None, mode='r|', fileobj=resp.raw)
         cart_tar.extractall(location)

--- a/pacifica/downloader/downloader.py
+++ b/pacifica/downloader/downloader.py
@@ -12,19 +12,19 @@ class Downloader(object):
     """
     Downloader Class.
 
-    The constructor takes one argument: `cart_api_url`.
-    The `cart_api_url` is the endpoint for creating carts.
-
     The other methods in this class are the supported
     download methods. Each method takes appropriate input for that
     method and the method will download the data to the location
     specified in the method's arguments.
     """
 
-    def __init__(self, cart_api_url, **kwargs):
-        """Create the downloader given directory location."""
-        self.auth = kwargs.get('auth', {})
-        self.cart_api = CartAPI(cart_api_url, auth=self.auth)
+    def __init__(self, **kwargs):
+        """
+        Create the downloader.
+
+        Keyword arguments are delegated to the CartAPI.
+        """
+        self.cart_api = CartAPI(**kwargs)
 
     def _download_from_url(self, location, cart_url, filename):
         """

--- a/tests/downloader_test.py
+++ b/tests/downloader_test.py
@@ -16,7 +16,7 @@ class TestDownloader(TestCase):
     def test_cart_api_url(self):
         """Test the CartAPI URL."""
         down = Downloader(proto='http', addr='127.0.0.1', port=8081)
-        self.assertEqual(down.cart_api._cart_api_url, 'http://127.0.0.1:8081')
+        self.assertEqual(down.cart_api.cart_api_url, 'http://127.0.0.1:8081')
 
     def test_download_policy(self):
         """Test the download with policy."""

--- a/tests/downloader_test.py
+++ b/tests/downloader_test.py
@@ -13,6 +13,11 @@ from pacifica.downloader import Downloader
 class TestDownloader(TestCase):
     """Test the Downloader class."""
 
+    def test_cart_api_url(self):
+        """Test the CartAPI URL."""
+        down = Downloader(proto='http', addr='127.0.0.1', port=8081)
+        self.assertEqual(down.cart_api._cart_api_url, 'http://127.0.0.1:8081')
+
     def test_download_policy(self):
         """Test the download with policy."""
         down_path = mkdtemp()

--- a/tests/downloader_test.py
+++ b/tests/downloader_test.py
@@ -16,7 +16,7 @@ class TestDownloader(TestCase):
     def test_download_policy(self):
         """Test the download with policy."""
         down_path = mkdtemp()
-        down = Downloader(down_path, 'http://127.0.0.1:8081')
+        down = Downloader(down_path, cart_api_url='http://127.0.0.1:8081')
         resp = requests.get('http://127.0.0.1:8181/status/transactions/by_id/67')
         self.assertEqual(resp.status_code, 200)
         down.transactioninfo(resp.json())
@@ -44,7 +44,7 @@ class TestDownloader(TestCase):
             ]
         }
         down_path = mkdtemp()
-        down = Downloader(down_path, 'http://127.0.0.1:8081')
+        down = Downloader(down_path, cart_api_url='http://127.0.0.1:8081')
         down.cloudevent(cloud_event_stub)
         for file_id in range(1100, 1110):
             self.assertTrue(


### PR DESCRIPTION
### Description

This pull request modifies the constructors for the `Downloader` and `CartAPI` classes so that CartAPI URLs are automatically constructed from either user-specified keyword arguments or OS environment variables.

The intent is that the type signature for the constructor for the `Downloader` class should resemble that of the [`Uploader`](https://github.com/pacifica/pacifica-python-uploader/blob/master/pacifica/uploader/uploader.py) (e.g., use keyword arguments to specify and/or construct URLs).

Changes:

- Added `CommonBase` class using code from https://github.com/pacifica/pacifica-python-uploader/blob/master/pacifica/uploader/common/__init__.py.
- Removed `auth` property from `Downloader` class. For a given instance `d`, use `d.cart_api._auth` instead of `d.auth`.

### Issues Resolved

n/a

### Check List

- [x] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
