### PR TITLE
Remove Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
-dist: xenial
+python: 3.6
+dist: bionic
 addons:
   apt:
     packages:
@@ -13,7 +14,7 @@ stages:
 - lint
 - test
 - deploy
-".before_script": &2
+before_script:
 - psql -c 'create database pacifica_metadata;' -U postgres
 - export ARCHIVEINTERFACE_CPCONFIG="$PWD/travis/archive/server.conf"
 - export ARCHIVEINTERFACE_CONFIG="$PWD/travis/archive/config.cfg"
@@ -53,7 +54,7 @@ stages:
 - export POLICY_CPCONFIG="$PWD/travis/policy/server.conf"
 - pacifica-policy & echo $! > policy.pid
 - python test_files/archiveinterfacepreload.py
-".script": &1
+script:
 - pip install .
 - cd tests
 - coverage run --include '*/site-packages/pacifica/downloader/*' -m pytest -xv
@@ -61,42 +62,18 @@ stages:
 jobs:
   include:
   - stage: lint
-    python: 3.6
-    script: pre-commit run -a
-  - python: 2.7
+    before_script: skip
     script: pre-commit run -a
   - stage: test
-    script: *1
-    before_script: *2
-    python: 3.6
-  - script: *1
-    before_script: *2
-    python: 2.7
   - stage: deploy
     services: []
-    language: python
-    before_install: skip
+    before_script: skip
     script: skip
-    python: 3.6
     deploy:
       skip_cleanup: true
       provider: pypi
       user: dmlb2000
       distributions: sdist bdist_wheel
-      password:
-        secure: atBJ8Qm8DUAfGBarfjOqt49Sdjcz0Cn4a6vYsT3zR5tY9KUISeZppIzvTTDoKyeUlHrc/djaIxV57CjPP24oDIktHdS8VoZZ/zJVa0CQabQrbmGi6JPhfcQuo388qnhFoJgT3rXE1ZxOc/Zjo2fIoM2w/2h4aIwiibO9EWVifRynDyUxpCjYuJ+T3shUYg4+cLfpxhy20/+s8RJkT/bZwihyfwrbBmayYl2uxWDVrZwsz1S3cW6LOjHlYh/gJQur9oW9d99ed9jmL15abJZkFCUOQx0gdVp0WLysMUON7vYYm0pSZXZ7+vn8hqejdEOTK5qr1N9pKAOEORSxQ4r35oZSk+KF88OZBnuGmbjAo93V6aDR+9rKvH5jk16ArviWp5MbdYprhvW+yPVxdh8mwHOnYAbLqRnGfbglSJqTJZ1kXTyjrezVipfH2O+8JO5zxWXHABidG8BIqA649Rw2GPWgov7Ri8dv5qfDLbvdsRkC2Yj47OFCoeNQacTnsLS0z1h+bvuREiXx953duOHLFfi1YhRxl85Ch6QqarL078wlCAVRFPPaiVrP8qFYqFifb9ex71lKEpFJwhEv/gwfr0NcAaOhXJ6IFhX74k3kOUze39BA2Y9rBul8x1KuJ7C8MRLquFceOdiY5iUvdxgS+/036du5JOhcov3fuQe/6UM=
-      on:
-        tags: true
-  - services: []
-    language: python
-    before_install: skip
-    script: skip
-    python: 2.7
-    deploy:
-      skip_cleanup: true
-      provider: pypi
-      user: dmlb2000
-      distributions: bdist_wheel
       password:
         secure: atBJ8Qm8DUAfGBarfjOqt49Sdjcz0Cn4a6vYsT3zR5tY9KUISeZppIzvTTDoKyeUlHrc/djaIxV57CjPP24oDIktHdS8VoZZ/zJVa0CQabQrbmGi6JPhfcQuo388qnhFoJgT3rXE1ZxOc/Zjo2fIoM2w/2h4aIwiibO9EWVifRynDyUxpCjYuJ+T3shUYg4+cLfpxhy20/+s8RJkT/bZwihyfwrbBmayYl2uxWDVrZwsz1S3cW6LOjHlYh/gJQur9oW9d99ed9jmL15abJZkFCUOQx0gdVp0WLysMUON7vYYm0pSZXZ7+vn8hqejdEOTK5qr1N9pKAOEORSxQ4r35oZSk+KF88OZBnuGmbjAo93V6aDR+9rKvH5jk16ArviWp5MbdYprhvW+yPVxdh8mwHOnYAbLqRnGfbglSJqTJZ1kXTyjrezVipfH2O+8JO5zxWXHABidG8BIqA649Rw2GPWgov7Ri8dv5qfDLbvdsRkC2Yj47OFCoeNQacTnsLS0z1h+bvuREiXx953duOHLFfi1YhRxl85Ch6QqarL078wlCAVRFPPaiVrP8qFYqFifb9ex71lKEpFJwhEv/gwfr0NcAaOhXJ6IFhX74k3kOUze39BA2Y9rBul8x1KuJ7C8MRLquFceOdiY5iUvdxgS+/036du5JOhcov3fuQe/6UM=
       on:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,6 @@ environment:
   BROKER_URL: redis://127.0.0.1:6379/0
   BACKEND_URL: redis://127.0.0.1:6379/0
   matrix:
-    - PYTHON: C:\Python27-x64
     - PYTHON: C:\Python36-x64
 
 install:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
-codeclimate-test-reporter
-coverage>4.0,<4.4
+coverage
 pacifica-archiveinterface
 pacifica-cartd
 pacifica-metadata
@@ -9,4 +8,3 @@ pre-commit
 pylint<2.0
 pytest
 recommonmark
-setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 setuptools
-six

--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,14 @@ setup(
     use_scm_version=True,
     setup_requires=['setuptools_scm'],
     description='Pacifica Python Downloader',
-    url='https://pypi.python.org/pypi/pacifica-downloader/',
+    url='https://github.com/pacifica/pacifica-python-downloader/',
     long_description=open(path.join(
         path.abspath(path.dirname(__file__)),
         'README.md')).read(),
     long_description_content_type='text/markdown',
     author='David Brown',
     author_email='david.brown@pnnl.gov',
-    packages=find_packages(),
+    packages=find_packages(include=['pacifica.*']),
     namespace_packages=['pacifica'],
     install_requires=[str(ir.req) for ir in INSTALL_REQS]
 )


### PR DESCRIPTION
### Description

This removes Python 2.7 support from Travis CI and Appveyor

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
