### PR TITLE
Add kwargs to upper level download methods

### DIFF
--- a/pacifica/downloader/downloader.py
+++ b/pacifica/downloader/downloader.py
@@ -40,7 +40,7 @@ class Downloader:
         cart_tar.extractall(location)
         cart_tar.close()
 
-    def transactioninfo(self, location, transinfo, filename='data'):
+    def transactioninfo(self, location, transinfo, **kwargs):
         """
         Handle transaction info and download the data in a cart.
 
@@ -52,12 +52,13 @@ class Downloader:
             self.cart_api.wait_for_cart(
                 self.cart_api.setup_cart(
                     TransactionInfo.yield_files(transinfo)
-                )
+                ),
+                int(kwargs.get('timeout', 120))
             ),
-            filename
+            kwargs.get('filename', 'data')
         )
 
-    def cloudevent(self, location, cloudevent, filename='data'):
+    def cloudevent(self, location, cloudevent, **kwargs):
         """
         Handle a cloud event and download the data in a cart.
 
@@ -73,7 +74,8 @@ class Downloader:
             self.cart_api.wait_for_cart(
                 self.cart_api.setup_cart(
                     CloudEvent.yield_files(cloudevent)
-                )
+                ),
+                int(kwargs.get('timeout', 120))
             ),
-            filename
+            kwargs.get('filename', 'data')
         )


### PR DESCRIPTION
### Description

This adds kwargs to both `transactioninfo()` and `cloudevent()`
methods in the upper level `Downloader` class. The filename is
moved to a kwargs and an optional timeout argument is also added.

Signed-off-by: David Brown <dmlb2000@gmail.com>


### Issues Resolved

Fix #24

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
